### PR TITLE
Fix bug al header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,10 @@
             {% if p.url == page.url %}
               <li><b><a href="{{ p.url }}">{{ p.title }}</a></b></li>
             {% else %}
-              <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+              {% assign ext = page.path | split: "." | last %}
+              {% if ext == "md" %}
+                <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+              {% endif %}
             {% endif %}
           {% endfor %}
         </ul>


### PR DESCRIPTION
Mirant el HTML de la web he vist que el bug sembla que és per el css que sembla que es genera
![2024-03-03-162451_257x210_scrot](https://github.com/hwfib/hwfib.github.io/assets/12856430/ff8fde49-4bb9-43e9-ab0e-561ebb5fb384)


Cambiant el codi per únicament incloure al header si és un fitxer.md hauria de funcionar tot sense problemes.

https://github.com/hwfib/hwfib.github.io/blob/f633ee7e1c24a15129bb453df245faa2b61c70ee/_layouts/default.html#L19-L22